### PR TITLE
Ensure cron runs

### DIFF
--- a/crons/run.js
+++ b/crons/run.js
@@ -1,8 +1,6 @@
 const { handler } = require('../crons');
 
 (async () => {
-
-  await handler()
-  process.exit()
-
-})()
+  await handler();
+  process.exit();
+})();

--- a/crons/run.js
+++ b/crons/run.js
@@ -1,6 +1,6 @@
 const { handler } = require('../crons');
 
 (async () => {
-  await handler();
+  await handler({ forceRunAll: true }); // Ensure cron tasks are run even if there is a delay in startup
   process.exit();
 })();


### PR DESCRIPTION
Cron is currently setup with the assumption that [crons.js](https://github.com/biblemesh/toad-reader-server/blob/8e8cb87a567b24a663bfbf8d48fbeb3589d687f3/crons.js) is run at least hourly, at the start of the hour and the start up is less than 60 seconds. Hourly and daily tasks run only if the process is executed within the first minute. This is currently the case, but if this changes it would result in all scheduled tasks silently failing.

Currently there is only a single hourly task, therefore the smallest change is to force this task to run given that this process is scheduled to run hourly. However I could instead change `crons.js` have separate functions for minutely, hourly and daily tasks and have separate `crons/run.js` files for each type (point 2 of https://github.com/biblemesh/ereader-development/issues/38).