### PR TITLE
DEBUG: Add Sentry breadcrumb for SQL queries

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,6 +1,8 @@
-const logger = {
+const logLevel = parseInt(process.env.LOG_LEVEL) || 3; // 1=verbose, 2=important, 3=errors only
+
+module.exports = {
+  logLevel,
   log: (msgs, importanceLevel) => {
-    const logLevel = parseInt(process.env.LOG_LEVEL) || 3; // 1=verbose, 2=important, 3=errors only
     importanceLevel = importanceLevel || 1;
     if (importanceLevel >= logLevel) {
       if (!Array.isArray(msgs)) {
@@ -22,5 +24,3 @@ const logger = {
     }
   },
 };
-
-module.exports = logger;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,10 +1,10 @@
 const logger = {
   log: (msgs, importanceLevel) => {
-    const logLevel = parseInt(process.env.LOG_LEVEL) || 3   // 1=verbose, 2=important, 3=errors only
-    importanceLevel = importanceLevel || 1
+    const logLevel = parseInt(process.env.LOG_LEVEL) || 3; // 1=verbose, 2=important, 3=errors only
+    importanceLevel = importanceLevel || 1;
     if (importanceLevel >= logLevel) {
       if (!Array.isArray(msgs)) {
-        msgs = [msgs]
+        msgs = [msgs];
       }
       const timestamp = new Date().toLocaleString('en-US', {
         timeZone: 'UTC',
@@ -17,10 +17,10 @@ const logger = {
         second: '2-digit',
         hour12: false, // 24-hour format
       }); // Start logs with timestamp to enabled log lines to be detected https://docs.aws.amazon.com/batch/latest/userguide/using_awslogs.html#create_awslogs_logdriver_options
-      msgs.unshift(timestamp, ['LOG ', 'INFO', 'ERR '][importanceLevel - 1])
-      console.log.apply(this, msgs)
+      msgs.unshift(timestamp, ['LOG ', 'INFO', 'ERR '][importanceLevel - 1]);
+      console.log.apply(this, msgs);
     }
-  }
-}
+  },
+};
 
-module.exports = logger
+module.exports = logger;

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1635,7 +1635,7 @@ const util = {
             type: 'info',
             category: 'query',
             message: query,
-            level: Sentry.Severity.Info,
+            level: 'info',
             data: {
               'db.statement': query,
               'db.params': vars,

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -21,7 +21,7 @@ const session = require('express-session');
 const MySQLStore = require('express-mysql-session')(session);
 const mysql = require('mysql2');
 const SqlString = require('sqlstring');
-const { log } = require('./logger');
+const { log, logLevel } = require('./logger');
 
 const getShopifyUserInfo = require('./getShopifyUserInfo');
 
@@ -1633,18 +1633,21 @@ const util = {
         // },
         vars,
         (err, result) => {
-          Sentry.addBreadcrumb({
-            type: 'query',
-            category: 'query',
-            message: query,
-            level: 'info',
-            data: {
-              'db.statement': query,
-              'db.params': vars,
-              'db.error': err,
-              'db.result': result,
-            },
-          });
+          if (err || logLevel <= 1) {
+            // verbose
+            Sentry.addBreadcrumb({
+              type: 'query',
+              category: 'query',
+              message: query,
+              level: 'info',
+              data: {
+                'db.statement': query,
+                'db.params': vars,
+                'db.error': err,
+                'db.result': result,
+              },
+            });
+          }
           if (err) {
             next(err);
             resolve();

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,3 +1,4 @@
+const Sentry = require('@sentry/node');
 const awsCaBundle = require('aws-ssl-profiles');
 const moment = require('moment');
 const jwt = require('jsonwebtoken');
@@ -1618,15 +1619,30 @@ const util = {
 
   runQuery: ({ query, queries, vars, next }) =>
     new Promise((resolve) => {
-      const { sql } = global.connection.query(
-        query || queries.join(';'),
+      /** @type mysql.Pool */
+      const connection = global.connection;
+      query = query ?? queries.join(';');
+      const { sql } = connection.query(
+        query,
         // The following did not seem to work
         // {
-        //   sql: query || queries.join(';'),
+        //   sql: query,
         //   timeout: 1000 * 10,
         // },
         vars,
         (err, result) => {
+          Sentry.addBreadcrumb({
+            type: 'info',
+            category: 'query',
+            message: query,
+            level: Sentry.Severity.Info,
+            data: {
+              'db.statement': query,
+              'db.params': vars,
+              'db.error': err,
+              'db.result': result,
+            },
+          });
           if (err) {
             next(err);
             resolve();

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1632,7 +1632,7 @@ const util = {
         vars,
         (err, result) => {
           Sentry.addBreadcrumb({
-            type: 'info',
+            type: 'query',
             category: 'query',
             message: query,
             level: 'info',


### PR DESCRIPTION
We have been seeing a few MySQL errors in Sentry since the switch to the mysql2 library, but Sentry is not logging the queries by default. Fix this to we know where these errors are coming from.

Example Sentry error: https://atxanka.sentry.io/issues/7342105732/
Screenshot (for @fydon):
<img width="1920" height="5317" alt="image" src="https://github.com/user-attachments/assets/434d39c8-8a8d-412e-9879-f5dd179ad324" />

Screenshot of the new breadcrumb in action:
<img width="1047" height="223" alt="image" src="https://github.com/user-attachments/assets/a5bffaf5-3d12-435f-af35-69eb0148929d" />
